### PR TITLE
Use native javascript trim() when available

### DIFF
--- a/Countable.js
+++ b/Countable.js
@@ -58,7 +58,13 @@
      */
 
     count: function () {
-      var str = (this.element.value || this.element.innerText || this.element.textContent || '').replace(/^\s+|\s+$/, '');
+        var str = (this.element.value || this.element.innerText || this.element.textContent || '');
+        if (typeof String.prototype.trim == 'function') {
+            str = str.trim();
+        }
+        else { 
+            str = str.replace(/^\s+|\s+$/, '');
+        }
 
       return {
         paragraphs: str ? (str.match(this.hard ? /\n{2,}/g : /\n+/g) || []).length + 1 : 0,


### PR DESCRIPTION
Instead of always using a regex replace, it will use the native trim
function when available. This results in increased performance on every
system with trim() implemented (Firefox 3.5+, Opera 11+, Safari 5+, Chrome
10+, Internet Explorer 9+).

Benchmarks: http://jsperf.com/wds1/10
