### PR TITLE
Fix for a bug if omit tag is missing like in the demo page the library breaks. 

### DIFF
--- a/Countable.js
+++ b/Countable.js
@@ -113,7 +113,7 @@
       var orig = (this.element.value || this.element.innerText || this.element.textContent || ''),
           tagRegEx = /<([a-zA-Z]+).*>(.*)<\/\1>/,
           isTag = tagRegEx.exec(orig),
-          askTag = (this.element.attributes.omit.value == "on"),
+          askTag = (this.element.attributes.omit) ? (this.element.attributes.omit.value == "on") : false,
           str = (isTag != null && askTag) ? isTag[2].trim() : orig.trim();
   
       return {


### PR DESCRIPTION
I didn't check if the omit attribute was there before asking for it's
value.  I added it on last minute and should have tested more
thoroughly. Sorry. http://jsfiddle.net/j6nkw/5/ 

I used a ternary (element.attribute.name) ? attr.value : false,
if that's cool then it should fix it
