### PR TITLE
Fix behaviour in textareas that have predefined innerText

### DIFF
--- a/Countable.js
+++ b/Countable.js
@@ -139,9 +139,15 @@
      */
 
     count: function () {
-      var orig = (this.element.value || this.element.innerText || this.element.textContent || ''),
-          temp = document.createElement('div'),
+      var temp = document.createElement('div'),
+          orig,
           str
+
+      if (this.element.value || this.element.value === '') {
+        orig = this.element.value
+      } else {
+        orig = (this.element.innerText || this.element.textContent || '')
+      }
 
       // Strip out HTML tags and trim leading and trailing whitespace.
 


### PR DESCRIPTION
In this example...

```
<textarea>foo</textarea>
```

`counter.all` returns `3` when a user deletes everything from the textarea (expect it to return `0`)

In the old `orig` assignment an empty string is evaluating to false so it moves on to the next option, `this.element.innerText`
