### PR TITLE
text2HTML option to transform text to HTML before counting.

### DIFF
--- a/Countable.js
+++ b/Countable.js
@@ -128,6 +128,8 @@
    * {Boolean}  hardReturns      Use two returns to seperate a paragraph
    *                             instead of one.
    * {Boolean}  stripTags        Strip HTML tags before counting the values.
+   * {Function} text2HTML        User supplied function to transform the values (markdown, etc.).
+   *                             Forces stripTags.
    * {Boolean}  ignoreReturns    Ignore returns when calculating the `all`
    *                             property.
    * {Boolean}  ignoreZeroWidth  Ignore zero-width space characters.
@@ -144,6 +146,7 @@
   function _extendDefaults (options) {
     var defaults = {
       hardReturns: false,
+      text2HTML: false,
       stripTags: false,
       ignoreReturns: false,
       ignoreZeroWidth: true
@@ -183,7 +186,8 @@
      * @see <http://goo.gl/gFQQh>
      */
 
-    if (options.stripTags) original = original.replace(/<\/?[a-z][^>]*>/gi, '')
+    if (options.text2HTML) original = options.text2HTML(original)
+    if (options.text2HTML || options.stripTags) original = original.replace(/<\/?[a-z][^>]*>/gi, '')
     if (options.ignoreZeroWidth) original = original.replace(/[\u200B]+/, '')
 
     trimmed = original.trim()

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Countable.enabled(area)
 {
   hardReturns: false,
   stripTags: false,
-  ignoreReturns: false
+  ignoreReturns: false,
+  text2HTML: false
 }
 ```
 
@@ -99,6 +100,8 @@ By default, paragraphs are split by a single return (a soft return). By setting 
 Depending on your application and audience, you might need to strip HTML tags from the text before counting it. You can do this by setting `stripTags` to true.
 
 In most cases, returns should be counted as part of the `all` property. Set `ignoreReturns` to false to remove them from the counter.
+
+You can also supply a function to transform the value to HTML before counting it. Handy if you're dealing with a markdown textarea, for example.
 
 ## Browser Support
 

--- a/test/test.js
+++ b/test/test.js
@@ -100,6 +100,12 @@ describe('Countable', function () {
       area.value = ''
     })
 
+    it('should transform text to html using supplied function and strip HTML tags', function () {
+      area.value = '<div>Hello [world](http://google.com)</div>'
+      Countable.once(area, callback, { text2HTML: function(){return '<div>Hello <a href="http://google.com">world</a></div>'} })
+      check([ '1', '1', '2', '10', '11' ])
+    })
+
     it('should strip HTML tags', function () {
       area.value = '<div>Hello <a href="http://google.com">world</a></div>'
       Countable.once(area, callback, { stripTags: true })


### PR DESCRIPTION
Adds no dependencies. I use it to transform a markdown textarea to html before counting it.