### PR TITLE
Force "keyup" event for IE 9 to handle DEL, BACKSPACE, and CUT command.

### DIFF
--- a/Countable.js
+++ b/Countable.js
@@ -30,6 +30,17 @@
       _event = 'oninput' in document ? 'input' : 'keyup'
 
   /**
+   * IE9 is a special case. It does not fire an 'input' event when
+   * characters are deleted (via DEL key, BACKSPACE key, and CUT).
+   * If we want support for those actions we need to use the 'keyup'
+   * event instead.
+   * more info: http://www.matts411.com/post/internet-explorer-9-oninput/
+   */
+  if (navigator.userAgent.match(/MSIE 9.0/)) {
+    _event = 'keyup'
+  }
+
+  /**
    * `String.trim()` polyfill for non-supporting browsers. This is the
    * recommended polyfill on MDN.
    *


### PR DESCRIPTION
Addresses #30