### PR TITLE
NPM package to lower case

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     </section>
     <section class="dark-section">
       <div class="wrap">
-        <pre><code class="terminal-line">bower install --save Countable</code><code class="terminal-line">npm install --save Countable</code></pre>
+        <pre><code class="terminal-line">bower install --save Countable</code><code class="terminal-line">npm install --save countable</code></pre>
         <p>The preferred method of installation is either <a href="https://github.com/bower/bower">bower</a> or <a href="https://npmjs.org">npm</a>. Alternatively, you can <a href="https://raw.github.com/RadLikeWhoa/Countable/master/Countable.js">download the script</a> directly. Out of the box, Countable can be used with AMD loaders (require.js), CommonJS loaders (node, browserify) or directly in the browser.</p>
       </div>
     </section>


### PR DESCRIPTION
NPM throws error using 'Countable' that package names "can no longer contain capital letters"