### PR TITLE
docs: Fix simple typo, vaild -> valid

### DIFF
--- a/Countable.js
+++ b/Countable.js
@@ -87,7 +87,7 @@
    *
    * @param   {Function}      callback  The callback function to validate.
    *
-   * @return  {Boolean}       Returns whether all arguments are vaild.
+   * @return  {Boolean}       Returns whether all arguments are valid.
    */
 
   function validateArguments (targets, callback) {


### PR DESCRIPTION
There is a small typo in Countable.js.

Should read `valid` rather than `vaild`.

